### PR TITLE
Nuevos test organizados en una subcarpeta.

### DIFF
--- a/tests/task/test_four.py
+++ b/tests/task/test_four.py
@@ -1,0 +1,22 @@
+from collections import namedtuple
+
+Task = namedtuple('Task', ['summary', 'owner', 'done', 'id'])
+Task.__new__.__defaults__ = (None, None, False, None)
+
+def test_asdict():
+    t_task = Task('do something', 'Smith', True, 21)
+    t_dict = t_task._asdict()
+    expected = {
+        'summary': 'do something',
+        'owner': 'Smith',
+        'done': True,
+        'id': 21
+    }
+    assert t_dict == expected
+
+def test_replace():
+    t_before = Task('finnish book', 'Brian', False)
+    t_after = t_before._replace(id=10, done=True)
+
+    t_expected = Task('finnish book', 'Brian', True, 10)
+    assert t_after == t_expected

--- a/tests/task/test_tree.py
+++ b/tests/task/test_tree.py
@@ -1,0 +1,15 @@
+from collections import namedtuple
+
+Task = namedtuple('Task', ['summary', 'owner', 'done', 'id'])
+Task.__new__.__defaults__ = (None, None, False, None)
+
+def test_default():
+    t1 = Task()
+    t2= Task(None, None, False, None)
+    assert t1 == t2
+
+def test_member_access():
+    t = Task('buy milk', 'Brian')
+    assert t.summary == 'buy milk'
+    assert t.owner == 'Brian'
+    assert (t.done, t.id) == (False, None)


### PR DESCRIPTION
Aquí vemos que se agrega una sub-carpeta de test para probar una clase Task() y PyTest realiza las pruebas dentro de la sub-carpeta de la carpeta test aún cuando esta no comience con el prefijo test_. 